### PR TITLE
Print the changed nodes

### DIFF
--- a/src/impact_analysis.py
+++ b/src/impact_analysis.py
@@ -237,7 +237,7 @@ def dbt_impact_analysis() -> str:
     # Step 1 - determine which dbt nodes are impacted by the changes in a given PR.
     changed_dbt_nodes = determine_changed_dbt_models()
     dbt_id_to_dbt_node = {node["unique_id"]: node for node in changed_dbt_nodes}
-    # print(changed_dbt_nodes)
+    print(changed_dbt_nodes)
 
     # Step 2 - map dbt nodes to datahub urns.
     # In an ideal world, the datahub urns for dbt would just be the dbt node ids.


### PR DESCRIPTION
Please let me know if its ok to print the changed nodes?

I am trying to debug why the impact analysis was returning more number of modified models in the PR when it shouldn't (even after checking directly on Acryl UI), the print logs will be helpful